### PR TITLE
Add cash flow algorithm to compute safe payment

### DIFF
--- a/cash_flow.py
+++ b/cash_flow.py
@@ -1,0 +1,100 @@
+"""Cash flow helper to find immediate safe payment amount.
+
+This module computes the maximum amount of money that can be paid today
+without causing future negative balances, given known future bills and
+incomes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Iterable, List
+
+
+@dataclass
+class CashEvent:
+    """Represents a dated cash flow event."""
+
+    date: date
+    amount: Decimal  # positive for income, negative for bills
+
+
+def _parse_date(value: date | str) -> date:
+    """Parse a ``date`` object or an ISO date string."""
+
+    if isinstance(value, date):
+        return value
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def _build_events(bills: Iterable[dict], incomes: Iterable[dict]) -> List[CashEvent]:
+    """Convert bill and income dictionaries into ``CashEvent`` objects."""
+
+    events: List[CashEvent] = []
+    for item in bills:
+        events.append(
+            CashEvent(
+                date=_parse_date(item["date"]),
+                amount=Decimal(str(item["amount"])) * Decimal("-1"),
+            )
+        )
+    for item in incomes:
+        events.append(
+            CashEvent(
+                date=_parse_date(item["date"]),
+                amount=Decimal(str(item["amount"])),
+            )
+        )
+    # Sort by date; on same day, incomes (positive) should apply before bills
+    events.sort(key=lambda e: (e.date, e.amount < 0))
+    return events
+
+
+def max_safe_payment(initial_balance: float | Decimal, bills: Iterable[dict], incomes: Iterable[dict]) -> Decimal:
+    """Return the largest amount that can be paid today without future overdraft.
+
+    Parameters
+    ----------
+    initial_balance:
+        Current amount of money available.
+    bills:
+        Iterable of dicts with ``amount`` and ``date`` keys for upcoming
+        obligations.
+    incomes:
+        Iterable of dicts with ``amount`` and ``date`` keys for known future
+        income.
+
+    Returns
+    -------
+    Decimal
+        The maximum additional payment that can be made immediately while
+        keeping the balance non-negative for all future events.
+    """
+
+    balance = Decimal(str(initial_balance))
+    events = _build_events(bills, incomes)
+
+    running = balance
+    min_balance = running
+    for event in events:
+        running += event.amount
+        if running < min_balance:
+            min_balance = running
+
+    # If the minimum future balance is negative, no additional payment can be
+    # made without going negative. Otherwise, that minimum is the safe payment.
+    return max(Decimal("0"), min_balance)
+
+
+if __name__ == "__main__":
+    # Example usage
+    current_balance = 1000
+    bills = [
+        {"amount": 300, "date": "2025-06-15"},
+        {"amount": 200, "date": "2025-06-20"},
+    ]
+    incomes = [{"amount": 1000, "date": "2025-06-25"}]
+
+    print("Max safe payment:", max_safe_payment(current_balance, bills, incomes))


### PR DESCRIPTION
## Summary
- add `cash_flow.py` with `max_safe_payment` to determine the largest amount that can be paid today without future overdraft

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ece48fd848328b58b2c03cecb627d