### PR TITLE
Implement event-based 60-day debt forecast

### DIFF
--- a/avalanche.py
+++ b/avalanche.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+"""Generate a daily debt payment schedule using the avalanche method.
+
+The schedule processes a chronologically sorted list of financial events and
+routes surplus cash to the highest-APR debt while ensuring upcoming bills are
+covered.  The algorithm operates on paydays: income is deposited, bills due
+before the next payday are paid, and any remaining safe cash (as calculated by
+:func:`cash_flow.max_safe_payment`) is sent as an extra payment toward the
+highest-APR debt.
+"""
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Iterable, List, Optional, Tuple
+from calendar import monthrange
+
+from cash_flow import max_safe_payment
+
+
+@dataclass
+class Event:
+    """Represents a financial event."""
+
+    date: date
+    type: str  # "paycheck", "bill", or "debt_min"
+    amount: Decimal
+    name: str
+
+
+@dataclass
+class Debt:
+    """Represents a debt with APR and balance."""
+
+    name: str
+    balance: Decimal
+    apr: Decimal
+    minimum_payment: Decimal
+    due_date: Optional[date] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+
+
+def _parse_date(value: date | str) -> date:
+    if isinstance(value, date):
+        return value
+    return datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def _add_month(d: date) -> date:
+    """Return a date one month after ``d`` preserving month length."""
+
+    year = d.year + (d.month // 12)
+    month = d.month % 12 + 1
+    day = min(d.day, monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def _build_events(
+    paychecks: Iterable[dict],
+    bills: Iterable[dict],
+    debts: Iterable[Debt],
+    start: date,
+    end: date,
+) -> List[Event]:
+    events: List[Event] = []
+    for p in paychecks:
+        pd = _parse_date(p["date"])
+        if pd > end:
+            continue
+        events.append(
+            Event(
+                date=pd,
+                type="paycheck",
+                amount=Decimal(str(p["amount"])),
+                name=p.get("name", "Paycheck"),
+            )
+        )
+    for b in bills:
+        current = _parse_date(b["date"])
+        while current <= end:
+            events.append(
+                Event(
+                    date=current,
+                    type="bill",
+                    amount=Decimal(str(b["amount"])),
+                    name=b.get("name", "Bill"),
+                )
+            )
+            current = _add_month(current)
+    for d in debts:
+        if d.due_date is None or d.minimum_payment <= 0:
+            continue
+        current = d.due_date
+        while current <= end:
+            events.append(Event(current, "debt_min", d.minimum_payment, d.name))
+            current = _add_month(current)
+    events.sort(key=lambda e: e.date)
+    return events
+
+
+def _next_due_date(due: Optional[date], end: date) -> Optional[date]:
+    if due is None:
+        return None
+    current = due
+    while current <= end:
+        current = _add_month(current)
+    return current
+
+
+# ---------------------------------------------------------------------------
+# Core algorithm
+
+
+def daily_avalanche_schedule(
+    starting_balance: float | Decimal,
+    paychecks: Iterable[dict],
+    bills: Iterable[dict],
+    debts_input: Iterable[dict],
+    days: int = 60,
+) -> Tuple[List[dict], List[dict]]:
+    """Return scheduled transactions and final debt balances using the avalanche method.
+
+    Parameters
+    ----------
+    starting_balance:
+        Current cash balance.
+    paychecks:
+        Iterable of dictionaries with ``amount`` and ``date`` keys.
+    bills:
+        Iterable of dictionaries with ``amount`` and ``date`` keys for regular
+        bills.
+    debts_input:
+        Iterable of dictionaries describing debts with keys ``name``, ``balance``,
+        ``apr``, ``minimum_payment`` and ``due_date``.
+    Returns
+    -------
+    Tuple[List[dict], List[dict]]
+        ``schedule`` of transactions and a list of remaining ``debts`` with updated balances.
+    """
+
+    balance = Decimal(str(starting_balance))
+
+    start = min(_parse_date(p["date"]) for p in paychecks)
+    end = start + timedelta(days=days)
+
+    # Prepare debt objects for tracking balances and APRs
+    debts: List[Debt] = [
+        Debt(
+            name=d["name"],
+            balance=Decimal(str(d["balance"])),
+            apr=Decimal(str(d["apr"])),
+            minimum_payment=Decimal(str(d.get("minimum_payment", 0))),
+            due_date=_parse_date(d["due_date"]) if d.get("due_date") else None,
+        )
+        for d in debts_input
+    ]
+    debt_lookup = {d.name: d for d in debts}
+
+    events = _build_events(paychecks, bills, debts, start, end)
+
+    # Separate lists for ease of future lookups
+    pay_events = [e for e in events if e.type == "paycheck"]
+    other_events = [e for e in events if e.type != "paycheck"]
+
+    schedule: List[dict] = []
+
+    for i, payday in enumerate(pay_events):
+        next_payday = pay_events[i + 1].date if i + 1 < len(pay_events) else None
+
+        # Deposit income
+        balance += payday.amount
+        schedule.append(
+            {
+                "date": payday.date,
+                "type": "paycheck",
+                "description": payday.name,
+                "amount": payday.amount,
+                "balance": balance,
+            }
+        )
+
+        # Pay bills/debt minimums due before the next payday on this payday
+        remaining_events: List[Event] = []
+        for ev in other_events:
+            due_now = ev.date <= payday.date or (next_payday is None or ev.date < next_payday)
+            if due_now:
+                payment_amount = ev.amount
+                if ev.type == "debt_min":
+                    debt = debt_lookup[ev.name]
+                    payment_amount = min(ev.amount, debt.balance)
+                    if payment_amount <= 0:
+                        continue
+                    debt.balance -= payment_amount
+                balance -= payment_amount
+                schedule.append(
+                    {
+                        "date": payday.date,
+                        "type": ev.type,
+                        "description": ev.name,
+                        "amount": -payment_amount,
+                        "balance": balance,
+                    }
+                )
+            else:
+                remaining_events.append(ev)
+        other_events = remaining_events
+
+        # Build future events for safe-payment calculation
+        future_bills = [
+            {"amount": ev.amount, "date": ev.date.isoformat()}
+            for ev in other_events
+        ]
+        future_incomes = [
+            {"amount": p.amount, "date": p.date.isoformat()}
+            for p in pay_events[i + 1 :]
+        ]
+        safe = max_safe_payment(balance, future_bills, future_incomes)
+
+        if safe > 0:
+            # Target highest-APR debt with remaining balance
+            active_debts = [d for d in debts if d.balance > 0]
+            if active_debts:
+                target = max(active_debts, key=lambda d: d.apr)
+                payment = min(safe, target.balance)
+                target.balance -= payment
+                balance -= payment
+                schedule.append(
+                    {
+                        "date": payday.date,
+                        "type": "extra",
+                        "description": f"Extra payment to {target.name}",
+                        "amount": -payment,
+                        "balance": balance,
+                    }
+                )
+
+    return schedule, [
+        {
+            "name": d.name,
+            "balance": d.balance,
+            "next_due_date": _next_due_date(d.due_date, end),
+        }
+        for d in debts
+    ]
+

--- a/fin.py
+++ b/fin.py
@@ -1,197 +1,150 @@
-import datetime
-from dateutil.relativedelta import relativedelta
-from decimal import Decimal, getcontext
-
-# Use Decimal for precise financial calculations
-getcontext().prec = 10
-
-def get_paydays_in_month(year, month, pay_cycle_start_date, frequency_weeks):
-    """
-    Calculates the number of paydays for a specific month.
-
-    Args:
-        year (int): The year of the month to check.
-        month (int): The month number (1-12) to check.
-        pay_cycle_start_date (date): A known date of a paycheck.
-        frequency_weeks (int): The number of weeks in the pay cycle (e.g., 2 for bi-weekly).
-
-    Returns:
-        int: The number of paydays in the specified month.
-    """
-    paydays = 0
-    p_date = pay_cycle_start_date
-    
-    # Find the first payday that is on or after the month we are looking for.
-    while p_date.year < year or (p_date.year == year and p_date.month < month):
-        p_date += relativedelta(weeks=frequency_weeks)
-        
-    p_date -= relativedelta(weeks=frequency_weeks)
-
-    # Now, iterate forward and count any paydays that fall within the target month.
-    while True:
-        p_date += relativedelta(weeks=frequency_weeks)
-        if p_date.year == year and p_date.month == month:
-            paydays += 1
-        elif p_date.year > year or (p_date.year == year and p_date.month > month):
-            break
-            
-    return paydays
-
-def calculate_snowball_plan(bills, incomes, debts, forecast_months):
-    """
-    Calculates a debt snowball payment plan based on monthly cash flow surplus.
-    """
-    # --- Data Initialization ---
-    for debt in debts:
-        debt['balance'] = Decimal(str(debt['balance']))
-        debt['minimum_payment'] = Decimal(str(debt['minimum_payment']))
-        debt['apr'] = Decimal(str(debt['apr']))
-        debt['paid_off'] = False
-
-    payment_schedule = []
-    total_interest_paid = Decimal('0')
-    
-    current_date = datetime.date.today().replace(day=1)
-    end_date = current_date + relativedelta(months=forecast_months)
-    
-    # --- Main Monthly Simulation Loop ---
-    month_count = 0
-    while any(not d['paid_off'] for d in debts) and current_date < end_date:
-        month_count += 1
-        
-        # --- 1. Calculate Accurate Monthly Income ---
-        monthly_income = Decimal('0')
-        for income in incomes:
-            amount = Decimal(str(income['amount']))
-            if income['frequency'] == 'monthly':
-                monthly_income += amount
-            elif income['frequency'] in ['bi-weekly', 'weekly']:
-                freq_weeks = 2 if income['frequency'] == 'bi-weekly' else 1
-                start_date = datetime.datetime.strptime(income['start_date'], '%Y-%m-%d').date()
-                num_paydays = get_paydays_in_month(current_date.year, current_date.month, start_date, freq_weeks)
-                monthly_income += amount * num_paydays
-
-        monthly_bills = sum(Decimal(str(b['amount'])) for b in bills)
-        cash_for_debts = monthly_income - monthly_bills
-        
-        # --- 2. Apply Interest and Sort Debts for Snowball ---
-        active_debts = sorted([d for d in debts if not d['paid_off']], key=lambda x: x['balance'])
-        
-        if not active_debts:
-            break
-
-        monthly_payments = {}
-        for debt in active_debts:
-            monthly_interest = debt['balance'] * (debt['apr'] / Decimal('100') / Decimal('12'))
-            debt['balance'] += monthly_interest
-            total_interest_paid += monthly_interest
-            monthly_payments[debt['name']] = {'interest': monthly_interest, 'payment': Decimal('0')}
-
-        # --- 3. CORRECTED: Distribute Payments with True Snowball Logic ---
-        available_for_payments = cash_for_debts
-        target_debt = active_debts[0]
-
-        # First, pay minimums on all NON-TARGET debts
-        for debt in active_debts:
-            if debt != target_debt:
-                # Pay the minimum, but not more than the balance or what's available
-                payment_amount = min(debt['minimum_payment'], debt['balance'])
-                actual_payment = min(available_for_payments, payment_amount)
-                
-                debt['balance'] -= actual_payment
-                available_for_payments -= actual_payment
-                monthly_payments[debt['name']]['payment'] = actual_payment
-                
-                if debt['balance'] <= 0:
-                    debt['paid_off'] = True
-
-        # Second, the ENTIRE remaining amount goes to the target debt
-        if target_debt and not target_debt['paid_off']:
-            target_payment_amount = min(available_for_payments, target_debt['balance'])
-            target_debt['balance'] -= target_payment_amount
-            monthly_payments[target_debt['name']]['payment'] = target_payment_amount
-            
-            if target_debt['balance'] <= 0:
-                target_debt['paid_off'] = True
+from collections import defaultdict
+from datetime import datetime, timedelta
+from decimal import Decimal
+from avalanche import daily_avalanche_schedule
 
 
-        # --- 4. Record the Month's Activity ---
-        payment_schedule.append({
-            'month': month_count,
-            'date': current_date.strftime('%B %Y'),
-            'details': monthly_payments,
-            'remaining_balances': {d['name']: d['balance'] for d in debts}
-        })
-        current_date += relativedelta(months=1)
-        
-    return payment_schedule, total_interest_paid
-
-def main():
-    """
-    Main function to define inputs and print the debt snowball forecast.
-    """
-    print("---  Debt Snowball Forecaster ---")
-    
-    # --- 📝 1. YOUR PERSONAL FINANCES ---
-    forecast_months = 84 # 7 years
+def main() -> None:
+    """Run a 60-day event-based debt forecast using the avalanche scheduler."""
+    print("---  Debt Avalanche Forecaster ---")
+    start_balance = Decimal(input("Enter current account balance: ").strip())
 
     bills = [
-        {'name': 'Rent', 'amount': 200.00},
-        {'name': 'Student Loan', 'amount': 184.86},
-        {'name': 'Car Insurance', 'amount': 206.33},
-        {'name': 'iCloud', 'amount': 9.99},
-        {'name': 'Copilot', 'amount': 13.00},
-        {'name': 'HP Instant Ink', 'amount': 8.43},
-        {'name': 'ChatGPT', 'amount': 20.00},
-        {'name': 'Gas', 'amount': 150.00},
-        {'name': 'Food', 'amount': 200.00},
-        {'name': 'Medications', 'amount': 50.97},
-        {'name': 'Tests', 'amount': 20.53},
+        {"name": "Rent", "amount": 200.00, "date": "2025-08-01"},
+        {"name": "Student Loan", "amount": 184.86, "date": "2025-08-05"},
+        {"name": "Car Insurance", "amount": 206.33, "date": "2025-08-10"},
+        {"name": "iCloud", "amount": 9.99, "date": "2025-08-15"},
+        {"name": "Copilot", "amount": 13.00, "date": "2025-08-20"},
+        {"name": "HP Instant Ink", "amount": 8.43, "date": "2025-08-25"},
+        {"name": "ChatGPT", "amount": 20.00, "date": "2025-09-01"},
+        {"name": "Gas", "amount": 150.00, "date": "2025-09-05"},
+        {"name": "Food", "amount": 200.00, "date": "2025-09-10"},
+        {"name": "Medications", "amount": 50.97, "date": "2025-09-15"},
+        {"name": "Tests", "amount": 20.53, "date": "2025-09-20"},
     ]
 
     incomes = [
-        {'name': 'Paycheck', 'amount': 1100.00, 'frequency': 'bi-weekly', 'start_date': '2025-08-12'},
+        {
+            "name": "Paycheck",
+            "amount": 1100.00,
+            "start_date": "2025-08-12",
+            "frequency": "bi-weekly",
+        }
     ]
+
+    def generate_paychecks(sources, days=60):
+        paychecks = []
+        for src in sources:
+            current = datetime.strptime(src["start_date"], "%Y-%m-%d").date()
+            end = current + timedelta(days=days)
+            delta = timedelta(weeks=2) if src["frequency"] == "bi-weekly" else timedelta(weeks=1)
+            while current <= end:
+                paychecks.append(
+                    {
+                        "name": src["name"],
+                        "amount": src["amount"],
+                        "date": current.isoformat(),
+                    }
+                )
+                current += delta
+        return paychecks
+
+    paychecks = generate_paychecks(incomes)
 
     debts = [
-        {'name': 'iPhone Installment', 'balance': 919.44, 'minimum_payment': 54.08, 'apr': 0.0},
-        {'name': 'Patient Fi Loan', 'balance': 1555.00, 'minimum_payment': 64.80, 'apr': 0.0},
-        {'name': 'Citi Card', 'balance': 1925.00, 'minimum_payment': 20.00, 'apr': 23.24},
-        {'name': 'Apple Card', 'balance': 4145.93, 'minimum_payment': 119.00, 'apr': 26.24},
-        {'name': 'Alpheon Loan', 'balance': 5195.00, 'minimum_payment': 153.00, 'apr': 0.0},
-        {'name': 'Auto Loan', 'balance': 25970.64, 'minimum_payment': 463.11, 'apr': 8.5},
+        {
+            "name": "iPhone Installment",
+            "balance": 919.44,
+            "minimum_payment": 54.08,
+            "apr": 0.0,
+            "due_date": "2025-08-28",
+        },
+        {
+            "name": "Patient Fi Loan",
+            "balance": 1555.00,
+            "minimum_payment": 64.80,
+            "apr": 0.0,
+            "due_date": "2025-09-02",
+        },
+        {
+            "name": "Citi Card",
+            "balance": 1925.00,
+            "minimum_payment": 20.00,
+            "apr": 23.24,
+            "due_date": "2025-08-25",
+        },
+        {
+            "name": "Apple Card",
+            "balance": 4145.93,
+            "minimum_payment": 119.00,
+            "apr": 26.24,
+            "due_date": "2025-09-07",
+        },
+        {
+            "name": "Alpheon Loan",
+            "balance": 5195.00,
+            "minimum_payment": 153.00,
+            "apr": 0.0,
+            "due_date": "2025-09-15",
+        },
+        {
+            "name": "Auto Loan",
+            "balance": 25970.64,
+            "minimum_payment": 463.11,
+            "apr": 8.5,
+            "due_date": "2025-09-20",
+        },
     ]
 
-    # --- ⚙️ 2. RUN THE CALCULATION ---
-    schedule, total_interest = calculate_snowball_plan(bills, incomes, debts, forecast_months)
+    schedule, debts_after = daily_avalanche_schedule(
+        start_balance, paychecks, bills, debts
+    )
 
-    # --- 📊 3. DISPLAY THE RESULT ---
-    if not schedule:
-        print("\nCould not generate a payment schedule. Check your income and bills.")
-        return
+    # Summarize events by date
+    daily = defaultdict(
+        lambda: {
+            "paycheck": Decimal("0"),
+            "bill": Decimal("0"),
+            "debt_min": Decimal("0"),
+            "extra": Decimal("0"),
+            "names": defaultdict(list),
+            "balance": Decimal("0"),
+        }
+    )
+    for ev in schedule:
+        day = ev["date"]
+        d = daily[day]
+        d[ev["type"]] += ev["amount"]
+        d["names"][ev["type"]].append((ev["description"], ev["amount"]))
+        d["balance"] = ev["balance"]
 
-    print("\n--- Your Debt Payoff Plan ---\n")
-    for month_data in schedule:
-        print(f"--- Month {month_data['month']}: {month_data['date']} ---")
-        sorted_debt_names = [d['name'] for d in debts]
-        for debt_name in sorted_debt_names:
-            if debt_name not in month_data['details']: continue
-            payment = month_data['details'][debt_name].get('payment', Decimal('0'))
-            new_balance = month_data['remaining_balances'][debt_name]
-            if new_balance <= 0 and (new_balance + payment) > 0:
-                 print(f"✅ {debt_name}: Paid off! (Final payment: ${payment:,.2f})")
-            elif new_balance > 0:
-                print(f"  - {debt_name}: Pay ${payment:,.2f}  (New Balance: ${new_balance:,.2f})")
-        print("-" * 40)
+    for day in sorted(daily):
+        d = daily[day]
+        print(
+            f"{day}: balance=${d['balance']:.2f} "
+            f"(income=${d['paycheck']:.2f}, bills=${-d['bill']:.2f}, "
+            f"minimums=${-d['debt_min']:.2f}, extra=${-d['extra']:.2f})"
+        )
+        for cat in ["paycheck", "bill", "debt_min", "extra"]:
+            if d["names"][cat]:
+                items = ", ".join(
+                    f"{name} ${(-amt if amt < 0 else amt):.2f}"
+                    for name, amt in d["names"][cat]
+                )
+                label = {
+                    "paycheck": "Income",
+                    "bill": "Bills",
+                    "debt_min": "Debt minimums",
+                    "extra": "Extra",
+                }[cat]
+                print(f"  {label}: {items}")
 
-    print("\n--- 🎉 Forecast Summary 🎉 ---")
-    if any(d['balance'] > 0 for d in debts):
-        print("Warning: Not all debts were paid off within the forecast period.")
-    else:
-        debt_free_date = schedule[-1]['date']
-        print(f"Projected Debt-Free Date: {debt_free_date}")
-        print(f"Total Months to Pay Off: {len(schedule)}")
-    print(f"Total Interest Paid: ${total_interest:,.2f}")
+    print("\nRemaining debt balances after 60 days:")
+    for d in debts_after:
+        due = d.get("next_due_date")
+        due_str = due.isoformat() if due else "N/A"
+        print(f"  {d['name']}: ${d['balance']:.2f} (next due {due_str})")
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -1,0 +1,41 @@
+import os
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the import path
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+from avalanche import daily_avalanche_schedule
+
+
+def test_balances_never_negative():
+    """Run the avalanche scheduler and ensure balances stay non-negative."""
+    paychecks = [
+        {"amount": 3000.0, "date": "2025-01-01"},
+        {"amount": 3000.0, "date": "2025-02-01"},
+    ]
+    bills = [
+        {"amount": 1000.0, "date": "2025-01-10"},
+        {"amount": 200.0, "date": "2025-01-20"},
+    ]
+    debts = [
+        {
+            "name": "Credit Card",
+            "balance": 500.0,
+            "apr": 15.0,
+            "minimum_payment": 50.0,
+            "due_date": "2025-01-25",
+        },
+        {
+            "name": "Car Loan",
+            "balance": 1500.0,
+            "apr": 6.0,
+            "minimum_payment": 100.0,
+            "due_date": "2025-02-15",
+        },
+    ]
+
+    schedule, _ = daily_avalanche_schedule(0, paychecks, bills, debts)
+
+    for event in schedule:
+        assert event["balance"] >= 0, f"Negative balance {event['balance']} on {event['date']}"


### PR DESCRIPTION
## Summary
- Restore user-provided bills, debts, and generate paychecks from a bi-weekly income source
- Group forecast output by date with daily totals and itemized names for incomes, bills, minimum debt payments, and extra payments
- Repeat bills and minimum debt payments monthly and display next payment date after the forecast
## Testing
- `python fin.py <<'EOF'
100
EOF`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ed75168b08328825fac2dcdba15e2