### PR TITLE
Accrue daily interest for debts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/__pycache__
+__pycache__/

--- a/tests/test_interest.py
+++ b/tests/test_interest.py
@@ -1,0 +1,22 @@
+import os
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+# Ensure project root on path for direct module imports
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+from avalanche import daily_avalanche_schedule
+
+
+def test_daily_interest_accrual():
+    debts = [{"name": "Loan", "balance": 1000.0, "apr": 36.5, "minimum_payment": 0.0}]
+    schedule, after = daily_avalanche_schedule(0, [], [], debts, days=2)
+    loan_balance = next(d["balance"] for d in after if d["name"] == "Loan")
+
+    rate = Decimal("36.5") / Decimal("36500")
+    expected = Decimal("1000")
+    for _ in range(3):
+        expected += expected * rate
+    precision = Decimal("0.000001")
+    assert loan_balance.quantize(precision) == expected.quantize(precision)


### PR DESCRIPTION
## Summary
- accrue daily interest on outstanding debts in avalanche scheduler
- add regression test for daily interest accrual
- ignore nested `__pycache__` directories

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689000c0a8088328ac7e78092f018dcb