### PR TITLE
Track debt payoff date in avalanche schedule

### DIFF
--- a/fin.py
+++ b/fin.py
@@ -65,9 +65,15 @@ def main() -> None:
 
     print(f"\nRemaining debt balances after {days} days:")
     for d in debts_after:
-        due = d.get("next_due_date")
-        due_str = due.isoformat() if due else "N/A"
-        print(f"  {d['name']}: ${d['balance']:.2f} (next due {due_str})")
+        paid = d.get("paid_off_date")
+        if paid:
+            print(
+                f"  {d['name']}: ${d['balance']:.2f} (paid off {paid.isoformat()})"
+            )
+        else:
+            due = d.get("next_due_date")
+            due_str = due.isoformat() if due else "N/A"
+            print(f"  {d['name']}: ${d['balance']:.2f} (next due {due_str})")
 
 
 if __name__ == "__main__":

--- a/tests/test_paid_off_date.py
+++ b/tests/test_paid_off_date.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+# Ensure project root on path for direct module imports
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+from avalanche import daily_avalanche_schedule
+
+
+def test_paid_off_debt_reports_date():
+    today = date.today()
+    debts = [
+        {
+            "name": "Loan",
+            "balance": 100.0,
+            "apr": 0.0,
+            "minimum_payment": 100.0,
+            "due_date": today.isoformat(),
+        }
+    ]
+    schedule, after = daily_avalanche_schedule(0, [], [], debts, days=30)
+    loan = next(d for d in after if d["name"] == "Loan")
+    assert loan["balance"] == 0
+    assert loan["paid_off_date"] == today
+    assert loan["next_due_date"] is None
+


### PR DESCRIPTION
## Summary
- Track when debts are fully repaid by adding a `paid_off_date` field to the debt model and updating the avalanche schedule logic to populate it.
- Return `paid_off_date` instead of `next_due_date` for cleared debts and adjust CLI output accordingly.
- Add regression test to ensure paid off debts report their payoff date.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890098eee8c8328b31a6d11eb826e78