### PR TITLE
Ensure safe payments account for future obligations

### DIFF
--- a/avalanche.py
+++ b/avalanche.py
@@ -184,6 +184,7 @@ def daily_avalanche_schedule(
 
     start = date.today()
     end = start + timedelta(days=days)
+    lookahead_end = max(end, start + timedelta(days=365))
 
     # Prepare debt objects for tracking balances and APRs
     debts: List[Debt] = [
@@ -198,7 +199,7 @@ def daily_avalanche_schedule(
     ]
     debt_lookup = {d.name: d for d in debts}
 
-    events = _build_events(paychecks, bills, debts, start, end)
+    events = _build_events(paychecks, bills, debts, start, lookahead_end)
 
     schedule: List[dict] = []
 

--- a/tests/test_safe_payment_lookahead.py
+++ b/tests/test_safe_payment_lookahead.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+# Ensure the project root is on the import path
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+from avalanche import daily_avalanche_schedule
+
+
+def test_schedule_independent_of_simulation_length():
+    """Schedules should match for overlapping period regardless of horizon."""
+    today = date.today()
+    bill_date = today + timedelta(days=31)
+    paycheck_date = today + timedelta(days=60)
+
+    bills = [{"amount": 800.0, "date": bill_date.isoformat()}]
+    paychecks = [{"amount": 1000.0, "date": paycheck_date.isoformat()}]
+    debts = [
+        {"name": "Card", "balance": 500.0, "apr": 0.0, "minimum_payment": 0.0}
+    ]
+
+    short_schedule, _ = daily_avalanche_schedule(
+        1000.0, paychecks, bills, debts, days=30
+    )
+    long_schedule, _ = daily_avalanche_schedule(
+        1000.0, paychecks, bills, debts, days=60
+    )
+
+    end_short = today + timedelta(days=30)
+    long_trimmed = [ev for ev in long_schedule if ev["date"] <= end_short]
+    assert short_schedule == long_trimmed


### PR DESCRIPTION
## Summary
- Expand avalanche scheduler to build events with a year-long lookahead so safe payments consider obligations beyond the simulation horizon.
- Add regression test verifying that payment schedules remain unchanged when simulation length varies.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900d6783d08328b10302e61c39a17e