### PR TITLE
Detect unavoidable negative balances in simulation

### DIFF
--- a/fin.py
+++ b/fin.py
@@ -20,9 +20,13 @@ def main() -> None:
     bills = data.get("bills", [])
     debts = data.get("debts", [])
 
-    schedule, debts_after = daily_avalanche_schedule(
-        start_balance, paychecks, bills, debts, days=days
-    )
+    try:
+        schedule, debts_after = daily_avalanche_schedule(
+            start_balance, paychecks, bills, debts, days=days
+        )
+    except ValueError as exc:
+        print(f"Warning: {exc}")
+        return
 
     # Summarize events by date
     daily = defaultdict(

--- a/tests/test_negative_balance.py
+++ b/tests/test_negative_balance.py
@@ -1,0 +1,19 @@
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+import pytest
+
+# Ensure project root on path for direct module imports
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+from avalanche import daily_avalanche_schedule
+
+
+def test_negative_balance_raises():
+    today = date.today()
+    future_bill = today + timedelta(days=10)
+    bills = [{"amount": 100.0, "date": future_bill.isoformat()}]
+
+    with pytest.raises(ValueError):
+        daily_avalanche_schedule(50.0, [], bills, [], days=30)

--- a/tests/test_paid_off_date.py
+++ b/tests/test_paid_off_date.py
@@ -20,7 +20,7 @@ def test_paid_off_debt_reports_date():
             "due_date": today.isoformat(),
         }
     ]
-    schedule, after = daily_avalanche_schedule(0, [], [], debts, days=30)
+    schedule, after = daily_avalanche_schedule(100, [], [], debts, days=30)
     loan = next(d for d in after if d["name"] == "Loan")
     assert loan["balance"] == 0
     assert loan["paid_off_date"] == today


### PR DESCRIPTION
## Summary
- halt the avalanche scheduler when current or projected payments would drive the cash balance negative
- add projected_min_balance helper for forecasting cash-flow shortfalls
- surface warnings in CLI and cover new behavior with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900fcd4d0083289ca445efd70f23d4