### PR TITLE
Add interactive finance menu and data editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-run fin.py to begin
+Run ``fin.py`` to begin.
 
-income, bills, and debt data is stored in financial_data.json
+Income, bills, and debt data is stored in ``financial_data.json``.
+The program starts with a simple menu that lets you edit income,
+bills, or debts before running the debt avalanche simulation.

--- a/fin.py
+++ b/fin.py
@@ -1,21 +1,72 @@
+"""Interactive finance tool with editing and simulation options."""
+
 from collections import defaultdict
 from decimal import Decimal
 from pathlib import Path
 import json
+
 from avalanche import daily_avalanche_schedule
 
 
-def main() -> None:
-    """Run an event-based debt forecast using the avalanche scheduler."""
+DATA_FILE = Path(__file__).with_name("financial_data.json")
+
+
+def load_data() -> dict:
+    with DATA_FILE.open() as f:
+        return json.load(f)
+
+
+def save_data(data: dict) -> None:
+    with DATA_FILE.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+def edit_section(section: str, fields: list[str], numeric_fields: set[str]) -> None:
+    """Generic editor for paychecks, bills, or debts."""
+
+    data = load_data()
+    items = data.setdefault(section, [])
+    while True:
+        print(f"\nCurrent {section}:")
+        for i, item in enumerate(items):
+            print(f"  {i}: {item}")
+        choice = input("Enter index to edit, 'a' to add, 'd' to delete, or blank to return: ").strip()
+        if not choice:
+            break
+        if choice == "a":
+            entry = {}
+            for field in fields:
+                val = input(f"{field}: ").strip()
+                if field in numeric_fields:
+                    val = float(val)
+                entry[field] = val
+            items.append(entry)
+        elif choice == "d":
+            idx = int(input("Index to delete: ").strip() or -1)
+            if 0 <= idx < len(items):
+                items.pop(idx)
+        elif choice.isdigit() and int(choice) < len(items):
+            idx = int(choice)
+            entry = items[idx]
+            for field in fields:
+                current = entry.get(field, "")
+                val = input(f"{field} [{current}]: ").strip()
+                if val:
+                    entry[field] = float(val) if field in numeric_fields else val
+        else:
+            print("Invalid selection.")
+    save_data(data)
+
+
+def run_simulation() -> None:
+    """Run the avalanche debt payoff simulation."""
+
     print("---  Debt Avalanche Forecaster ---")
     days_str = input("Enter number of days to simulate [60]: ").strip()
     days = int(days_str) if days_str else 60
     start_balance = Decimal(input("Enter current account balance: ").strip())
 
-    data_file = Path(__file__).with_name("financial_data.json")
-    with data_file.open() as f:
-        data = json.load(f)
-
+    data = load_data()
     paychecks = data.get("paychecks", [])
     bills = data.get("bills", [])
     debts = data.get("debts", [])
@@ -28,7 +79,6 @@ def main() -> None:
         print(f"Warning: {exc}")
         return
 
-    # Summarize events by date
     daily = defaultdict(
         lambda: {
             "paycheck": Decimal("0"),
@@ -80,5 +130,31 @@ def main() -> None:
             print(f"  {d['name']}: ${d['balance']:.2f} (next due {due_str})")
 
 
+def main() -> None:
+    while True:
+        print("\n--- Finance Menu ---")
+        print("1) Edit income")
+        print("2) Edit bills")
+        print("3) Edit debt")
+        print("4) Run simulation")
+        print("5) Quit")
+        choice = input("Choose an option: ").strip()
+        if choice == "1":
+            edit_section("paychecks", ["name", "amount", "date", "frequency"], {"amount"})
+        elif choice == "2":
+            edit_section("bills", ["name", "amount", "date"], {"amount"})
+        elif choice == "3":
+            edit_section(
+                "debts",
+                ["name", "balance", "minimum_payment", "apr", "due_date"],
+                {"balance", "minimum_payment", "apr"},
+            )
+        elif choice == "4":
+            run_simulation()
+        elif choice in {"5", "q", "Q"}:
+            break
+
+
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- add startup menu for editing income, bills, debts or running a simulation
- allow in-place editing of financial data stored in `financial_data.json`
- avoid negative balance checks for paid-off debts and only raise warnings within the simulation horizon

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890186204048328a2c08b62e1e63345