### PR TITLE
Add interactive finance menu

### DIFF
--- a/avalanche.py
+++ b/avalanche.py
@@ -261,6 +261,7 @@ def daily_avalanche_schedule(
             {"amount": ev.amount, "date": ev.date.isoformat()}
             for ev in future_events
             if ev.type != "paycheck"
+            and (ev.type != "debt_min" or debt_lookup[ev.name].balance > 0)
         ]
         future_incomes = [
             {"amount": ev.amount, "date": ev.date.isoformat()}
@@ -271,7 +272,7 @@ def daily_avalanche_schedule(
         min_balance, negative_date = projected_min_balance(
             balance, future_bills, future_incomes
         )
-        if negative_date is not None:
+        if negative_date is not None and negative_date <= end:
             raise ValueError(
                 f"Balance would go negative on {negative_date}"  # pragma: no cover - string only
             )

--- a/fin.py
+++ b/fin.py
@@ -1,20 +1,130 @@
+"""Command-line interface for managing finances and running simulations."""
+
 from collections import defaultdict
 from decimal import Decimal
 from pathlib import Path
 import json
+from typing import Dict, List
+
 from avalanche import daily_avalanche_schedule
 
 
-def main() -> None:
-    """Run an event-based debt forecast using the avalanche scheduler."""
+DATA_FILE = Path(__file__).with_name("financial_data.json")
+
+
+def load_data() -> Dict:
+    """Load financial data from ``financial_data.json``."""
+    if DATA_FILE.exists():
+        with DATA_FILE.open() as f:
+            return json.load(f)
+    return {"paychecks": [], "bills": [], "debts": []}
+
+
+def save_data(data: Dict) -> None:
+    """Persist financial data to disk."""
+    with DATA_FILE.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Editing helpers
+
+
+def _delete_item(items: List[dict]) -> None:
+    idx = input("Number to delete: ").strip()
+    if idx.isdigit() and 1 <= int(idx) <= len(items):
+        del items[int(idx) - 1]
+
+
+def edit_paychecks(data: Dict) -> None:
+    """Add or remove recurring income entries."""
+    paychecks = data.setdefault("paychecks", [])
+    while True:
+        print("\nCurrent paychecks:")
+        for i, p in enumerate(paychecks, 1):
+            freq = p.get("frequency", "monthly")
+            print(f"{i}. {p['name']} ${p['amount']} starting {p['date']} ({freq})")
+        action = input("A)dd, D)elete, B)ack: ").strip().lower()
+        if action == "a":
+            name = input("Name: ").strip() or "Paycheck"
+            amount = float(input("Amount: ").strip())
+            date = input("First date (YYYY-MM-DD): ").strip()
+            freq = input("Frequency [monthly]: ").strip() or "monthly"
+            paychecks.append(
+                {"name": name, "amount": amount, "date": date, "frequency": freq}
+            )
+            save_data(data)
+        elif action == "d":
+            _delete_item(paychecks)
+            save_data(data)
+        elif action == "b":
+            break
+
+
+def edit_bills(data: Dict) -> None:
+    """Add or remove bill entries."""
+    bills = data.setdefault("bills", [])
+    while True:
+        print("\nCurrent bills:")
+        for i, b in enumerate(bills, 1):
+            print(f"{i}. {b['name']} ${b['amount']} due {b['date']}")
+        action = input("A)dd, D)elete, B)ack: ").strip().lower()
+        if action == "a":
+            name = input("Name: ").strip() or "Bill"
+            amount = float(input("Amount: ").strip())
+            date = input("Due date (YYYY-MM-DD): ").strip()
+            bills.append({"name": name, "amount": amount, "date": date})
+            save_data(data)
+        elif action == "d":
+            _delete_item(bills)
+            save_data(data)
+        elif action == "b":
+            break
+
+
+def edit_debts(data: Dict) -> None:
+    """Add or remove debt entries."""
+    debts = data.setdefault("debts", [])
+    while True:
+        print("\nCurrent debts:")
+        for i, d in enumerate(debts, 1):
+            print(
+                f"{i}. {d['name']} balance ${d['balance']} min ${d['minimum_payment']} APR {d['apr']} due {d['due_date']}"
+            )
+        action = input("A)dd, D)elete, B)ack: ").strip().lower()
+        if action == "a":
+            name = input("Name: ").strip() or "Debt"
+            balance = float(input("Balance: ").strip())
+            minimum = float(input("Minimum payment: ").strip())
+            apr = float(input("APR: ").strip())
+            due = input("Next due date (YYYY-MM-DD): ").strip()
+            debts.append(
+                {
+                    "name": name,
+                    "balance": balance,
+                    "minimum_payment": minimum,
+                    "apr": apr,
+                    "due_date": due,
+                }
+            )
+            save_data(data)
+        elif action == "d":
+            _delete_item(debts)
+            save_data(data)
+        elif action == "b":
+            break
+
+
+# ---------------------------------------------------------------------------
+# Simulation
+
+
+def run_simulation(data: Dict) -> None:
+    """Run the avalanche debt payoff simulation."""
     print("---  Debt Avalanche Forecaster ---")
     days_str = input("Enter number of days to simulate [60]: ").strip()
     days = int(days_str) if days_str else 60
     start_balance = Decimal(input("Enter current account balance: ").strip())
-
-    data_file = Path(__file__).with_name("financial_data.json")
-    with data_file.open() as f:
-        data = json.load(f)
 
     paychecks = data.get("paychecks", [])
     bills = data.get("bills", [])
@@ -80,5 +190,35 @@ def main() -> None:
             print(f"  {d['name']}: ${d['balance']:.2f} (next due {due_str})")
 
 
+# ---------------------------------------------------------------------------
+# Menu
+
+
+def main() -> None:
+    """Display the main menu and handle user selections."""
+    data = load_data()
+    while True:
+        print("\n--- Finance Menu ---")
+        print("1. Edit income")
+        print("2. Edit bills")
+        print("3. Edit debts")
+        print("4. Run simulation")
+        print("5. Quit")
+        choice = input("Select an option: ").strip()
+        if choice == "1":
+            edit_paychecks(data)
+        elif choice == "2":
+            edit_bills(data)
+        elif choice == "3":
+            edit_debts(data)
+        elif choice == "4":
+            run_simulation(data)
+        elif choice == "5":
+            break
+        else:
+            print("Invalid option.")
+
+
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- Add a user-friendly CLI menu to edit income, bills, debts and run the avalanche simulation
- Persist financial data edits to JSON and refactor simulation into `run_simulation`
- Improve avalanche scheduler by ignoring future payments for cleared debts and limiting negative-balance warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890186204048328a2c08b62e1e63345