### PR TITLE
Allow bills to add to debt instead of reducing balance

### DIFF
--- a/fin.py
+++ b/fin.py
@@ -1,20 +1,130 @@
+"""Command-line interface for managing finances and running simulations."""
+
 from collections import defaultdict
 from decimal import Decimal
 from pathlib import Path
 import json
+from typing import Dict, List
+
 from avalanche import daily_avalanche_schedule
 
 
-def main() -> None:
-    """Run an event-based debt forecast using the avalanche scheduler."""
+DATA_FILE = Path(__file__).with_name("financial_data.json")
+
+
+def load_data() -> Dict:
+    """Load financial data from ``financial_data.json``."""
+    if DATA_FILE.exists():
+        with DATA_FILE.open() as f:
+            return json.load(f)
+    return {"paychecks": [], "bills": [], "debts": []}
+
+
+def save_data(data: Dict) -> None:
+    """Persist financial data to disk."""
+    with DATA_FILE.open("w") as f:
+        json.dump(data, f, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Editing helpers
+
+
+def _delete_item(items: List[dict]) -> None:
+    idx = input("Number to delete: ").strip()
+    if idx.isdigit() and 1 <= int(idx) <= len(items):
+        del items[int(idx) - 1]
+
+
+def edit_paychecks(data: Dict) -> None:
+    """Add or remove recurring income entries."""
+    paychecks = data.setdefault("paychecks", [])
+    while True:
+        print("\nCurrent paychecks:")
+        for i, p in enumerate(paychecks, 1):
+            freq = p.get("frequency", "monthly")
+            print(f"{i}. {p['name']} ${p['amount']} starting {p['date']} ({freq})")
+        action = input("A)dd, D)elete, B)ack: ").strip().lower()
+        if action == "a":
+            name = input("Name: ").strip() or "Paycheck"
+            amount = float(input("Amount: ").strip())
+            date = input("First date (YYYY-MM-DD): ").strip()
+            freq = input("Frequency [monthly]: ").strip() or "monthly"
+            paychecks.append(
+                {"name": name, "amount": amount, "date": date, "frequency": freq}
+            )
+            save_data(data)
+        elif action == "d":
+            _delete_item(paychecks)
+            save_data(data)
+        elif action == "b":
+            break
+
+
+def edit_bills(data: Dict) -> None:
+    """Add or remove bill entries."""
+    bills = data.setdefault("bills", [])
+    while True:
+        print("\nCurrent bills:")
+        for i, b in enumerate(bills, 1):
+            print(f"{i}. {b['name']} ${b['amount']} due {b['date']}")
+        action = input("A)dd, D)elete, B)ack: ").strip().lower()
+        if action == "a":
+            name = input("Name: ").strip() or "Bill"
+            amount = float(input("Amount: ").strip())
+            date = input("Due date (YYYY-MM-DD): ").strip()
+            bills.append({"name": name, "amount": amount, "date": date})
+            save_data(data)
+        elif action == "d":
+            _delete_item(bills)
+            save_data(data)
+        elif action == "b":
+            break
+
+
+def edit_debts(data: Dict) -> None:
+    """Add or remove debt entries."""
+    debts = data.setdefault("debts", [])
+    while True:
+        print("\nCurrent debts:")
+        for i, d in enumerate(debts, 1):
+            print(
+                f"{i}. {d['name']} balance ${d['balance']} min ${d['minimum_payment']} APR {d['apr']} due {d['due_date']}"
+            )
+        action = input("A)dd, D)elete, B)ack: ").strip().lower()
+        if action == "a":
+            name = input("Name: ").strip() or "Debt"
+            balance = float(input("Balance: ").strip())
+            minimum = float(input("Minimum payment: ").strip())
+            apr = float(input("APR: ").strip())
+            due = input("Next due date (YYYY-MM-DD): ").strip()
+            debts.append(
+                {
+                    "name": name,
+                    "balance": balance,
+                    "minimum_payment": minimum,
+                    "apr": apr,
+                    "due_date": due,
+                }
+            )
+            save_data(data)
+        elif action == "d":
+            _delete_item(debts)
+            save_data(data)
+        elif action == "b":
+            break
+
+
+# ---------------------------------------------------------------------------
+# Simulation
+
+
+def run_simulation(data: Dict) -> None:
+    """Run the avalanche debt payoff simulation."""
     print("---  Debt Avalanche Forecaster ---")
     days_str = input("Enter number of days to simulate [60]: ").strip()
     days = int(days_str) if days_str else 60
     start_balance = Decimal(input("Enter current account balance: ").strip())
-
-    data_file = Path(__file__).with_name("financial_data.json")
-    with data_file.open() as f:
-        data = json.load(f)
 
     paychecks = data.get("paychecks", [])
     bills = data.get("bills", [])
@@ -80,5 +190,35 @@ def main() -> None:
             print(f"  {d['name']}: ${d['balance']:.2f} (next due {due_str})")
 
 
+# ---------------------------------------------------------------------------
+# Menu
+
+
+def main() -> None:
+    """Display the main menu and handle user selections."""
+    data = load_data()
+    while True:
+        print("\n--- Finance Menu ---")
+        print("1. Edit income")
+        print("2. Edit bills")
+        print("3. Edit debts")
+        print("4. Run simulation")
+        print("5. Quit")
+        choice = input("Select an option: ").strip()
+        if choice == "1":
+            edit_paychecks(data)
+        elif choice == "2":
+            edit_bills(data)
+        elif choice == "3":
+            edit_debts(data)
+        elif choice == "4":
+            run_simulation(data)
+        elif choice == "5":
+            break
+        else:
+            print("Invalid option.")
+
+
 if __name__ == "__main__":
     main()
+

--- a/tests/test_debt_bill.py
+++ b/tests/test_debt_bill.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+# Ensure the project root is on the import path
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+from avalanche import daily_avalanche_schedule
+
+
+def test_bill_adds_to_debt_not_balance():
+    today = date.today()
+    bills = [
+        {"amount": 200.0, "date": today.isoformat(), "debt": "Card", "name": "Purchase"}
+    ]
+    debts = [
+        {"name": "Card", "balance": 0.0, "apr": 0.0, "minimum_payment": 0.0}
+    ]
+
+    schedule, after = daily_avalanche_schedule(0, [], bills, debts, days=30)
+
+    assert schedule[0]["type"] == "debt_add"
+    assert schedule[0]["balance"] == 0
+    assert schedule[0]["amount"] == 0
+
+    card = next(d for d in after if d["name"] == "Card")
+    assert float(card["balance"]) == 200.0


### PR DESCRIPTION
## Summary
- Support `debt_add` events so bills can increase a specified debt without affecting cash balance
- Exclude debt additions and already-paid debts from projected cash-flow calculations
- Merge with latest `main` branch to keep logic in sync with recent updates
- Add regression test ensuring debt-linked bills update debt balances and leave account balance untouched

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689017a65d808328977c6e589d5d5332