### PR TITLE
Add optional debt association for bills

### DIFF
--- a/avalanche.py
+++ b/avalanche.py
@@ -259,7 +259,7 @@ def daily_avalanche_schedule(
                         "date": ev.date,
                         "type": ev.type,
                         "description": ev.name,
-                        "amount": Decimal("0"),
+                        "amount": ev.amount,
                         "balance": balance,
                     }
                 )

--- a/fin.py
+++ b/fin.py
@@ -44,7 +44,7 @@ def edit_paychecks(data: Dict) -> None:
         for i, p in enumerate(paychecks, 1):
             freq = p.get("frequency", "monthly")
             print(f"{i}. {p['name']} ${p['amount']} starting {p['date']} ({freq})")
-        action = input("A)dd, D)elete, B)ack: ").strip().lower()
+        action = input("A)dd, E)dit, D)elete, B)ack: ").strip().lower()
         if action == "a":
             name = input("Name: ").strip() or "Paycheck"
             amount = float(input("Amount: ").strip())
@@ -54,6 +54,20 @@ def edit_paychecks(data: Dict) -> None:
                 {"name": name, "amount": amount, "date": date, "frequency": freq}
             )
             save_data(data)
+        elif action == "e":
+            idx = input("Number to edit: ").strip()
+            if idx.isdigit() and 1 <= int(idx) <= len(paychecks):
+                p = paychecks[int(idx) - 1]
+                name = input(f"Name [{p['name']}]: ").strip() or p['name']
+                amount = input(f"Amount [{p['amount']}]: ").strip()
+                date = input(f"First date (YYYY-MM-DD) [{p['date']}]: ").strip() or p['date']
+                freq = input(
+                    f"Frequency [{p.get('frequency', 'monthly')}]: "
+                ).strip() or p.get("frequency", "monthly")
+                if amount:
+                    p['amount'] = float(amount)
+                p.update({"name": name, "date": date, "frequency": freq})
+                save_data(data)
         elif action == "d":
             _delete_item(paychecks)
             save_data(data)
@@ -70,7 +84,7 @@ def edit_bills(data: Dict) -> None:
         for i, b in enumerate(bills, 1):
             debt_info = f" (debt: {b['debt']})" if b.get("debt") else ""
             print(f"{i}. {b['name']} ${b['amount']} due {b['date']}{debt_info}")
-        action = input("A)dd, D)elete, B)ack: ").strip().lower()
+        action = input("A)dd, E)dit, D)elete, B)ack: ").strip().lower()
         if action == "a":
             name = input("Name: ").strip() or "Bill"
             amount = float(input("Amount: ").strip())
@@ -93,6 +107,36 @@ def edit_bills(data: Dict) -> None:
                 bill["debt"] = debt
             bills.append(bill)
             save_data(data)
+        elif action == "e":
+            idx = input("Number to edit: ").strip()
+            if idx.isdigit() and 1 <= int(idx) <= len(bills):
+                b = bills[int(idx) - 1]
+                name = input(f"Name [{b['name']}]: ").strip() or b['name']
+                amount = input(f"Amount [{b['amount']}]: ").strip()
+                date = input(f"Due date (YYYY-MM-DD) [{b['date']}]: ").strip() or b['date']
+                b.update({"name": name, "date": date})
+                if amount:
+                    b['amount'] = float(amount)
+                if debts:
+                    while True:
+                        print("Associate with debt? (0 for none)")
+                        for i, d in enumerate(debts, 1):
+                            print(f"{i}. {d['name']}")
+                        current = next(
+                            (i + 1 for i, d in enumerate(debts) if d['name'] == b.get('debt')),
+                            0,
+                        )
+                        choice = input(f"Debt number [{current}]: ").strip()
+                        if not choice:
+                            choice = str(current)
+                        if choice == "0":
+                            b.pop("debt", None)
+                            break
+                        if choice.isdigit() and 1 <= int(choice) <= len(debts):
+                            b["debt"] = debts[int(choice) - 1]["name"]
+                            break
+                        print("Invalid selection. Please try again.")
+                save_data(data)
         elif action == "d":
             _delete_item(bills)
             save_data(data)
@@ -109,7 +153,7 @@ def edit_debts(data: Dict) -> None:
             print(
                 f"{i}. {d['name']} balance ${d['balance']} min ${d['minimum_payment']} APR {d['apr']} due {d['due_date']}"
             )
-        action = input("A)dd, D)elete, B)ack: ").strip().lower()
+        action = input("A)dd, E)dit, D)elete, B)ack: ").strip().lower()
         if action == "a":
             name = input("Name: ").strip() or "Debt"
             balance = float(input("Balance: ").strip())
@@ -126,6 +170,25 @@ def edit_debts(data: Dict) -> None:
                 }
             )
             save_data(data)
+        elif action == "e":
+            idx = input("Number to edit: ").strip()
+            if idx.isdigit() and 1 <= int(idx) <= len(debts):
+                d = debts[int(idx) - 1]
+                name = input(f"Name [{d['name']}]: ").strip() or d['name']
+                balance = input(f"Balance [{d['balance']}]: ").strip()
+                minimum = input(f"Minimum payment [{d['minimum_payment']}]: ").strip()
+                apr = input(f"APR [{d['apr']}]: ").strip()
+                due = input(
+                    f"Next due date (YYYY-MM-DD) [{d.get('due_date', '')}]: "
+                ).strip() or d.get("due_date", "")
+                if balance:
+                    d['balance'] = float(balance)
+                if minimum:
+                    d['minimum_payment'] = float(minimum)
+                if apr:
+                    d['apr'] = float(apr)
+                d.update({"name": name, "due_date": due})
+                save_data(data)
         elif action == "d":
             _delete_item(debts)
             save_data(data)

--- a/fin.py
+++ b/fin.py
@@ -163,6 +163,7 @@ def run_simulation(data: Dict) -> None:
             "bill": Decimal("0"),
             "debt_min": Decimal("0"),
             "extra": Decimal("0"),
+            "debt_add": Decimal("0"),
             "names": defaultdict(list),
             "balance": Decimal("0"),
         }
@@ -170,6 +171,8 @@ def run_simulation(data: Dict) -> None:
     for ev in schedule:
         day = ev["date"]
         d = daily[day]
+        if ev["type"] not in d:
+            d[ev["type"]] = Decimal("0")
         d[ev["type"]] += ev["amount"]
         d["names"][ev["type"]].append((ev["description"], ev["amount"]))
         d["balance"] = ev["balance"]
@@ -181,7 +184,7 @@ def run_simulation(data: Dict) -> None:
             f"(income=${d['paycheck']:.2f}, bills=${-d['bill']:.2f}, "
             f"minimums=${-d['debt_min']:.2f}, extra=${-d['extra']:.2f})"
         )
-        for cat in ["paycheck", "bill", "debt_min", "extra"]:
+        for cat in ["paycheck", "bill", "debt_min", "extra", "debt_add"]:
             if d["names"][cat]:
                 items = ", ".join(
                     f"{name} ${(-amt if amt < 0 else amt):.2f}"
@@ -192,6 +195,7 @@ def run_simulation(data: Dict) -> None:
                     "bill": "Bills",
                     "debt_min": "Debt minimums",
                     "extra": "Extra",
+                    "debt_add": "Debt additions",
                 }[cat]
                 print(f"  {label}: {items}")
 

--- a/fin.py
+++ b/fin.py
@@ -64,7 +64,7 @@ def edit_paychecks(data: Dict) -> None:
 def edit_bills(data: Dict) -> None:
     """Add or remove bill entries."""
     bills = data.setdefault("bills", [])
-    debt_names = {d["name"] for d in data.get("debts", [])}
+    debts = data.get("debts", [])
     while True:
         print("\nCurrent bills:")
         for i, b in enumerate(bills, 1):
@@ -76,14 +76,18 @@ def edit_bills(data: Dict) -> None:
             amount = float(input("Amount: ").strip())
             date = input("Due date (YYYY-MM-DD): ").strip()
             debt = None
-            while True:
-                debt_input = input("Associate with debt [none]: ").strip()
-                if not debt_input:
-                    break
-                if debt_input in debt_names:
-                    debt = debt_input
-                    break
-                print("Debt not found. Please try again.")
+            if debts:
+                while True:
+                    print("Associate with debt? (0 for none)")
+                    for i, d in enumerate(debts, 1):
+                        print(f"{i}. {d['name']}")
+                    choice = input("Debt number [0]: ").strip()
+                    if not choice or choice == "0":
+                        break
+                    if choice.isdigit() and 1 <= int(choice) <= len(debts):
+                        debt = debts[int(choice) - 1]["name"]
+                        break
+                    print("Invalid selection. Please try again.")
             bill = {"name": name, "amount": amount, "date": date}
             if debt:
                 bill["debt"] = debt

--- a/financial_data.json
+++ b/financial_data.json
@@ -2,24 +2,81 @@
   "paychecks": [
     {
       "name": "Paycheck",
-      "amount": 1100.00,
+      "amount": 1100.0,
       "date": "2025-07-29",
       "frequency": "biweekly"
     }
   ],
   "bills": [
-    {"name": "Rent", "amount": 200.00, "date": "2025-07-01"},
-    {"name": "Student Loan", "amount": 184.86, "date": "2025-07-01"},
-    {"name": "ChatGPT", "amount": 20.00, "date": "2025-08-01"},
-    {"name": "iCloud", "amount": 9.99, "date": "2025-07-01"},
-    {"name": "Car Insurance", "amount": 206.33, "date": "2025-07-10"},
-    {"name": "Cellular", "amount": 35.00, "date": "2025-07-04"},
-    {"name": "HP Instant Ink", "amount": 8.43, "date": "2025-07-08"},
-    {"name": "Copilot", "amount": 13.00, "date": "2025-07-20"},
-    {"name": "Gas", "amount": 150.00, "date": "2025-08-05"},
-    {"name": "Food", "amount": 200.00, "date": "2025-08-05"},
-    {"name": "Medications", "amount": 50.97, "date": "2025-08-30"},
-    {"name": "Tests", "amount": 20.53, "date": "2025-08-30"}
+    {
+      "name": "Rent",
+      "amount": 200.0,
+      "date": "2025-07-01"
+    },
+    {
+      "name": "Student Loan",
+      "amount": 184.86,
+      "date": "2025-07-01"
+    },
+    {
+      "name": "ChatGPT",
+      "amount": 20.0,
+      "date": "2025-08-01",
+      "debt": "Apple Card"
+    },
+    {
+      "name": "iCloud",
+      "amount": 9.99,
+      "date": "2025-07-01",
+      "debt": "Apple Card"
+    },
+    {
+      "name": "Car Insurance",
+      "amount": 206.33,
+      "date": "2025-07-10"
+    },
+    {
+      "name": "Cellular",
+      "amount": 35.0,
+      "date": "2025-07-04",
+      "debt": "Apple Card"
+    },
+    {
+      "name": "HP Instant Ink",
+      "amount": 8.43,
+      "date": "2025-07-08",
+      "debt": "Apple Card"
+    },
+    {
+      "name": "Copilot",
+      "amount": 13.0,
+      "date": "2025-07-20",
+      "debt": "Apple Card"
+    },
+    {
+      "name": "Gas",
+      "amount": 150.0,
+      "date": "2025-08-05",
+      "debt": "Apple Card"
+    },
+    {
+      "name": "Food",
+      "amount": 200.0,
+      "date": "2025-08-05",
+      "debt": "Apple Card"
+    },
+    {
+      "name": "Medications",
+      "amount": 50.97,
+      "date": "2025-08-30",
+      "debt": "Apple Card"
+    },
+    {
+      "name": "Tests",
+      "amount": 20.53,
+      "date": "2025-08-30",
+      "debt": "Apple Card"
+    }
   ],
   "debts": [
     {
@@ -31,15 +88,15 @@
     },
     {
       "name": "Patient Fi Loan",
-      "balance": 1555.00,
-      "minimum_payment": 64.80,
+      "balance": 1555.0,
+      "minimum_payment": 64.8,
       "apr": 0.0,
       "due_date": "2025-08-02"
     },
     {
       "name": "Citi Card",
-      "balance": 1925.00,
-      "minimum_payment": 20.00,
+      "balance": 1925.0,
+      "minimum_payment": 20.0,
       "apr": 23.24,
       "due_date": "2025-07-25"
     },
@@ -52,8 +109,8 @@
     },
     {
       "name": "Alpheon Loan",
-      "balance": 5195.00,
-      "minimum_payment": 153.00,
+      "balance": 5195.0,
+      "minimum_payment": 153.0,
       "apr": 0.0,
       "due_date": "2025-08-15"
     },

--- a/tests/test_debt_bill.py
+++ b/tests/test_debt_bill.py
@@ -22,7 +22,7 @@ def test_bill_adds_to_debt_not_balance():
 
     assert schedule[0]["type"] == "debt_add"
     assert schedule[0]["balance"] == 0
-    assert schedule[0]["amount"] == 0
+    assert float(schedule[0]["amount"]) == 200.0
 
     card = next(d for d in after if d["name"] == "Card")
     assert float(card["balance"]) == 200.0

--- a/tests/test_edit_items.py
+++ b/tests/test_edit_items.py
@@ -1,0 +1,74 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+import fin
+
+
+def _mock_inputs(monkeypatch, inputs):
+    it = iter(inputs)
+    monkeypatch.setattr("builtins.input", lambda _: next(it))
+    monkeypatch.setattr(fin, "save_data", lambda data: None)
+
+
+def test_edit_paycheck(monkeypatch):
+    data = {
+        "paychecks": [
+            {"name": "Job", "amount": 1000.0, "date": "2024-01-01", "frequency": "monthly"}
+        ]
+    }
+    _mock_inputs(monkeypatch, [
+        "e", "1", "Job2", "2000", "2024-02-01", "biweekly", "b"
+    ])
+    fin.edit_paychecks(data)
+    p = data["paychecks"][0]
+    assert p["name"] == "Job2"
+    assert p["amount"] == 2000.0
+    assert p["date"] == "2024-02-01"
+    assert p["frequency"] == "biweekly"
+
+
+def test_edit_bill(monkeypatch):
+    data = {
+        "bills": [{"name": "Rent", "amount": 100.0, "date": "2024-01-05"}],
+        "debts": [
+            {
+                "name": "Card",
+                "balance": 0.0,
+                "minimum_payment": 0.0,
+                "apr": 0.0,
+                "due_date": "2024-01-10",
+            }
+        ],
+    }
+    _mock_inputs(monkeypatch, ["e", "1", "", "150", "", "1", "b"])
+    fin.edit_bills(data)
+    b = data["bills"][0]
+    assert b["amount"] == 150.0
+    assert b["debt"] == "Card"
+
+
+def test_edit_debt(monkeypatch):
+    data = {
+        "debts": [
+            {
+                "name": "Card",
+                "balance": 100.0,
+                "minimum_payment": 10.0,
+                "apr": 5.0,
+                "due_date": "2024-01-10",
+            }
+        ]
+    }
+    _mock_inputs(monkeypatch, [
+        "e", "1", "Card2", "150", "15", "7", "2024-02-10", "b"
+    ])
+    fin.edit_debts(data)
+    d = data["debts"][0]
+    assert d["name"] == "Card2"
+    assert d["balance"] == 150.0
+    assert d["minimum_payment"] == 15.0
+    assert d["apr"] == 7.0
+    assert d["due_date"] == "2024-02-10"

--- a/tests/test_run_simulation_debt_add.py
+++ b/tests/test_run_simulation_debt_add.py
@@ -7,6 +7,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
 
 import fin
+from avalanche import daily_avalanche_schedule
 
 
 def test_run_simulation_handles_debt_add(monkeypatch, capsys):
@@ -36,3 +37,10 @@ def test_run_simulation_handles_debt_add(monkeypatch, capsys):
     fin.run_simulation(data)
     output = capsys.readouterr().out
     assert "Debt additions" in output
+    assert "Purchase $25.00" in output
+
+    schedule, _ = daily_avalanche_schedule(
+        0, [], data["bills"], data["debts"], days=1
+    )
+    assert schedule[0]["amount"] == 25
+    assert schedule[0]["balance"] == 0

--- a/tests/test_run_simulation_debt_add.py
+++ b/tests/test_run_simulation_debt_add.py
@@ -1,0 +1,38 @@
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+# Ensure project root in path
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+import fin
+
+
+def test_run_simulation_handles_debt_add(monkeypatch, capsys):
+    data = {
+        "paychecks": [],
+        "bills": [
+            {
+                "name": "Purchase",
+                "amount": 25.0,
+                "date": date.today().isoformat(),
+                "debt": "Card",
+            }
+        ],
+        "debts": [
+            {
+                "name": "Card",
+                "balance": 0.0,
+                "apr": 0.0,
+                "minimum_payment": 0.0,
+            }
+        ],
+    }
+
+    inputs = iter(["1", "0"])  # simulate one day and $0 balance
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    fin.run_simulation(data)
+    output = capsys.readouterr().out
+    assert "Debt additions" in output


### PR DESCRIPTION
## Summary
- Allow users to link bills to existing debts with validation and display of associated debt
- Persist optional bill-to-debt links in saved data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68901fe1e3c08328b4dc4dbe63df72c5