### PR TITLE
Add debug simulation option

### DIFF
--- a/tests/test_run_simulation_debug_mode.py
+++ b/tests/test_run_simulation_debug_mode.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+# Ensure project root in path
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+import fin
+
+
+def test_run_simulation_debug_mode(monkeypatch, capsys):
+    data = {
+        "paychecks": [],
+        "bills": [
+            {
+                "name": "Big bill",
+                "amount": 100.0,
+                "date": date.today().isoformat(),
+            }
+        ],
+        "debts": [],
+    }
+
+    inputs = iter(["1", "0", "n"])
+    monkeypatch.setattr("builtins.input", lambda _: next(inputs))
+
+    fin.run_simulation(data, debug=True)
+    out = capsys.readouterr().out
+    assert "<<< LOW BALANCE" in out


### PR DESCRIPTION
## Summary
- allow run_simulation to run in a debug mode that can log daily debt balances and continue through negative cash
- add menu option to invoke the debug simulation directly
- test debug simulation output for low-balance indicator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890b2e666088328ad6e63ccbbe33d33