### PR TITLE
Add total interest tracking for loans

### DIFF
--- a/avalanche.py
+++ b/avalanche.py
@@ -41,6 +41,7 @@ class Debt:
     minimum_payment: Decimal
     due_date: Optional[date] = None
     paid_off_date: Optional[date] = None
+    interest_accrued: Decimal = Decimal("0")
 
 
 # ---------------------------------------------------------------------------
@@ -458,6 +459,7 @@ def daily_avalanche_schedule(
             if debt.balance > 0 and debt.apr > 0:
                 interest = debt.balance * debt.apr / Decimal("36500")
                 debt.balance += interest
+                debt.interest_accrued += interest
 
         if debug and debt_log is not None:
             debt_log.append(
@@ -474,6 +476,7 @@ def daily_avalanche_schedule(
         {
             "name": d.name,
             "balance": d.balance,
+            "interest_accrued": d.interest_accrued,
             "next_due_date": None
             if d.paid_off_date
             else _next_due_date(d.due_date, end),

--- a/fin.py
+++ b/fin.py
@@ -316,15 +316,18 @@ def run_simulation(data: Dict, debug: bool = False) -> None:
 
     print(f"\nRemaining debt balances after {days} days:")
     for d in debts_after:
+        interest = d.get("interest_accrued", Decimal("0"))
         paid = d.get("paid_off_date")
         if paid:
             print(
-                f"  {d['name']}: ${d['balance']:.2f} (paid off {paid.isoformat()})"
+                f"  {d['name']}: ${d['balance']:.2f} (paid off {paid.isoformat()}, total interest ${interest:.2f})",
             )
         else:
             due = d.get("next_due_date")
             due_str = due.isoformat() if due else "N/A"
-            print(f"  {d['name']}: ${d['balance']:.2f} (next due {due_str})")
+            print(
+                f"  {d['name']}: ${d['balance']:.2f} (next due {due_str}, total interest ${interest:.2f})",
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_interest.py
+++ b/tests/test_interest.py
@@ -12,7 +12,9 @@ from avalanche import daily_avalanche_schedule
 def test_daily_interest_accrual():
     debts = [{"name": "Loan", "balance": 1000.0, "apr": 36.5, "minimum_payment": 0.0}]
     schedule, after, _ = daily_avalanche_schedule(0, [], [], debts, days=2)
-    loan_balance = next(d["balance"] for d in after if d["name"] == "Loan")
+    loan_info = next(d for d in after if d["name"] == "Loan")
+    loan_balance = loan_info["balance"]
+    interest = loan_info["interest_accrued"]
 
     rate = Decimal("36.5") / Decimal("36500")
     expected = Decimal("1000")
@@ -20,3 +22,5 @@ def test_daily_interest_accrual():
         expected += expected * rate
     precision = Decimal("0.000001")
     assert loan_balance.quantize(precision) == expected.quantize(precision)
+    expected_interest = expected - Decimal("1000")
+    assert interest.quantize(precision) == expected_interest.quantize(precision)


### PR DESCRIPTION
## Summary
- Track interest accrued per debt in the avalanche simulation
- Show total interest for each loan at the end of a simulation
- Test that total interest is calculated correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890b2f1ffd88328b5b1968107a07e02