### PR TITLE
Allow custom minimum payment formulas

### DIFF
--- a/apple_card_interest.py
+++ b/apple_card_interest.py
@@ -1,0 +1,48 @@
+from datetime import date, timedelta
+from decimal import Decimal
+
+def calculate_interest(purchases, payments, statement_start, statement_end, apr):
+    """
+    Calculate interest for a statement period.
+
+    purchases: List of (amount, date) tuples for purchases.
+    payments: List of (amount, date) tuples for payments.
+    statement_start: Start date of the statement period.
+    statement_end: End date of the statement period.
+    apr: Annual percentage rate (as a Decimal, e.g. Decimal('19.99')).
+    """
+    # Build daily balance
+    balance = Decimal("0")
+    daily_balances = []
+    current_date = statement_start
+
+    # Sort transactions by date
+    purchases = sorted(purchases, key=lambda x: x[1])
+    payments = sorted(payments, key=lambda x: x[1])
+
+    purchase_idx = 0
+    payment_idx = 0
+
+    while current_date <= statement_end:
+        # Add purchases for the day
+        while purchase_idx < len(purchases) and purchases[purchase_idx][1] == current_date:
+            balance += Decimal(str(purchases[purchase_idx][0]))
+            purchase_idx += 1
+        # Subtract payments for the day
+        while payment_idx < len(payments) and payments[payment_idx][1] == current_date:
+            balance -= Decimal(str(payments[payment_idx][0]))
+            payment_idx += 1
+        daily_balances.append(balance)
+        current_date += timedelta(days=1)
+
+    # Calculate average daily balance
+    avg_daily_balance = sum(daily_balances) / Decimal(len(daily_balances))
+
+    # Calculate interest: (APR / 365) * avg_daily_balance * number of days
+    interest = (apr / Decimal("100") / Decimal("365")) * avg_daily_balance * Decimal(len(daily_balances))
+    return interest.quantize(Decimal("0.01"))
+
+# Example usage:
+# purchases = [(100, date(2025, 7, 5)), (50, date(2025, 7, 10))]
+# payments = [(80, date(2025, 7, 15))]
+# interest = calculate_interest(purchases, payments, date(2025, 7, 1), date(2025, 7, 31), Decimal("19.99"))

--- a/apple_card_minimum_payment.py
+++ b/apple_card_minimum_payment.py
@@ -1,0 +1,24 @@
+import math
+
+def appleCardMinimumPayment(
+    statement_balance,
+    interest_accrued,
+    installment_payments,
+    daily_cash_adjustments
+    ):
+    # Calculate 1% of statement balance
+    one_percent_balance = statement_balance * 0.01
+
+    # Sum daily cash adjustments
+    daily_cash_adj_total = sum(daily_cash_adjustments)
+
+    # Calculate the sum as per agreement
+    payment_sum = one_percent_balance + interest_accrued + daily_cash_adj_total
+
+    # Round up to the nearest dollar
+    rounded_sum = math.ceil(payment_sum)
+
+    # Add installment payments
+    final_minimum_payment = rounded_sum + installment_payments
+
+    return final_minimum_payment

--- a/fin.py
+++ b/fin.py
@@ -260,6 +260,16 @@ def run_simulation(data: Dict, debug: bool = False) -> None:
     paychecks = data.get("paychecks", [])
     bills = data.get("bills", [])
     debts = data.get("debts", [])
+    for d in debts:
+        if d.get("min_payment_formula") == "apple_card":
+            if d.get("installment_due") and d.get("installment_term") and not d.get("financing_balance"):
+                d["financing_balance"] = float(Decimal(str(d["installment_due"])) * Decimal(str(d["installment_term"])))
+            if d.get("interest_billed", 0) in (0, "0", 0.0):
+                resp = input(
+                    f"Interest charged on last {d['name']} statement [0]: "
+                ).strip()
+                if resp:
+                    d["interest_billed"] = float(resp)
     goals = [g for g in data.get("goals", []) if g.get("enabled", True)]
 
     debt_log = None

--- a/fin.py
+++ b/fin.py
@@ -337,6 +337,11 @@ def run_simulation(data: Dict, debug: bool = False) -> None:
         d["balance"] = ev["balance"]
 
     debt_map = {entry["date"]: entry["debts"] for entry in debt_log} if debt_log else {}
+    interest_map = (
+        {entry["date"]: entry.get("interest_charges", {}) for entry in debt_log}
+        if debt_log
+        else {}
+    )
 
     for day in sorted(daily):
         d = daily[day]
@@ -344,7 +349,13 @@ def run_simulation(data: Dict, debug: bool = False) -> None:
         line = f"{day}: balance=${d['balance']:.2f}{marker}"
         if debt_map:
             debts_str = ", ".join(
-                f"{name}=${bal:.2f}" for name, bal in debt_map.get(day, {}).items()
+                f"{name}=${bal:.2f}"
+                + (
+                    f" (interest=${interest_map.get(day, {}).get(name, Decimal('0')):.2f})"
+                    if interest_map
+                    else ""
+                )
+                for name, bal in debt_map.get(day, {}).items()
             )
             if debts_str:
                 line += f" | debts: {debts_str}"

--- a/financial_data.json
+++ b/financial_data.json
@@ -98,7 +98,8 @@
       "minimum_payment": 20.0,
       "apr": 23.24,
       "due_date": "2025-07-25",
-      "min_payment_formula": "credit_card"
+      "min_payment_formula": "credit_card",
+      "interest_method": "credit_card"
     },
     {
       "name": "Apple Card",
@@ -107,6 +108,7 @@
       "apr": 26.24,
       "due_date": "2025-08-11",
       "min_payment_formula": "apple_card",
+      "interest_method": "apple_card",
       "unpaid_daily_cash": 0,
       "interest_billed": 0,
       "past_due": 0,

--- a/financial_data.json
+++ b/financial_data.json
@@ -81,7 +81,8 @@
       "name": "iPhone Installment",
       "amount": 54.08,
       "date": "2025-07-31",
-      "debt": "Apple Card"
+      "debt": "Apple Card",
+      "term_months": 24
     }
   ],
   "debts": [
@@ -104,7 +105,7 @@
     {
       "name": "Apple Card",
       "balance": 4145.93,
-      "minimum_payment": 173.08,
+      "minimum_payment": 0.0,
       "apr": 26.24,
       "due_date": "2025-08-11",
       "min_payment_formula": "apple_card",
@@ -112,7 +113,9 @@
       "unpaid_daily_cash": 0,
       "interest_billed": 0,
       "past_due": 0,
-      "installment_due": 54.08
+      "installment_due": 54.08,
+      "installment_term": 24,
+      "financing_balance": 1297.92
     },
     {
       "name": "Alpheon Loan",

--- a/financial_data.json
+++ b/financial_data.json
@@ -98,14 +98,21 @@
       "balance": 1925.0,
       "minimum_payment": 20.0,
       "apr": 23.24,
-      "due_date": "2025-07-25"
+      "due_date": "2025-07-25",
+      "min_payment_formula": "credit_card"
     },
     {
       "name": "Apple Card",
       "balance": 4145.93,
       "minimum_payment": 173.08,
       "apr": 26.24,
-      "due_date": "2025-08-11"
+      "due_date": "2025-08-11",
+      "min_payment_formula": "apple_card",
+      "unpaid_daily_cash": 0,
+      "interest_billed": 0,
+      "past_due": 0,
+      "financing_balance": 0,
+      "installment_due": 0
     },
     {
       "name": "Alpheon Loan",

--- a/financial_data.json
+++ b/financial_data.json
@@ -76,16 +76,15 @@
       "amount": 20.53,
       "date": "2025-08-30",
       "debt": "Apple Card"
+    },
+    {
+      "name": "iPhone Installment",
+      "amount": 54.08,
+      "date": "2025-07-31",
+      "debt": "Apple Card"
     }
   ],
   "debts": [
-    {
-      "name": "iPhone Installment",
-      "balance": 919.44,
-      "minimum_payment": 54.08,
-      "apr": 0.0,
-      "due_date": "2025-07-28"
-    },
     {
       "name": "Patient Fi Loan",
       "balance": 1555.0,
@@ -111,8 +110,7 @@
       "unpaid_daily_cash": 0,
       "interest_billed": 0,
       "past_due": 0,
-      "financing_balance": 0,
-      "installment_due": 0
+      "installment_due": 54.08
     },
     {
       "name": "Alpheon Loan",

--- a/interest.py
+++ b/interest.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+"""Interest calculation methods for debts.
+
+Each method exposes functions to handle new charges, daily accrual and
+end-of-month processing. Methods are registered in ``INTEREST_METHODS`` so
+that debts can specify which calculation to use.
+"""
+
+from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
+from calendar import monthrange
+from typing import Callable, Dict
+
+
+def _add_month(d: date) -> date:
+    """Return a date one month after ``d`` preserving month length."""
+    year = d.year + (d.month // 12)
+    month = d.month % 12 + 1
+    day = min(d.day, monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+# ---------------------------------------------------------------------------
+# Generic credit card interest
+
+
+def credit_card_add_charge(debt, amount: Decimal, ch_date: date) -> None:
+    debt.balance_subject_to_interest += amount
+
+
+def credit_card_daily(debt, current_date: date) -> None:
+    if debt.balance_subject_to_interest > 0 and debt.apr > 0:
+        interest = debt.balance_subject_to_interest * debt.apr / Decimal("36500")
+        debt.interest_buffer += interest
+        debt.interest_accrued += interest
+
+
+def credit_card_month_end(debt, current_date: date) -> Decimal:
+    if debt.interest_buffer > 0:
+        billed = debt.interest_buffer.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        debt.interest_buffer = Decimal("0")
+        return billed
+    return Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# Apple Card interest
+
+
+def apple_card_add_charge(debt, amount: Decimal, ch_date: date) -> None:
+    if debt.balance_subject_to_interest == 0:
+        debt.grace_charges.append((ch_date, amount))
+    else:
+        debt.balance_subject_to_interest += amount
+
+
+def apple_card_daily(debt, current_date: date) -> None:
+    credit_card_daily(debt, current_date)
+    if debt.due_date and current_date == debt.due_date and debt.grace_charges:
+        for ch_date, amt in debt.grace_charges:
+            days = (current_date - ch_date).days + 1
+            retro = amt * debt.apr / Decimal("36500") * days
+            debt.interest_buffer += retro
+            debt.interest_accrued += retro
+            debt.balance_subject_to_interest += amt
+        debt.grace_charges.clear()
+        debt.due_date = _add_month(debt.due_date)
+
+
+def apple_card_month_end(debt, current_date: date) -> Decimal:
+    return credit_card_month_end(debt, current_date)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+
+
+class InterestMethod:
+    def __init__(self, add_charge: Callable, daily: Callable, month_end: Callable):
+        self.add_charge = add_charge
+        self.daily = daily
+        self.month_end = month_end
+
+
+INTEREST_METHODS: Dict[str, InterestMethod] = {
+    "credit_card": InterestMethod(
+        add_charge=credit_card_add_charge,
+        daily=credit_card_daily,
+        month_end=credit_card_month_end,
+    ),
+    "apple_card": InterestMethod(
+        add_charge=apple_card_add_charge,
+        daily=apple_card_daily,
+        month_end=apple_card_month_end,
+    ),
+}

--- a/minimum_payments.py
+++ b/minimum_payments.py
@@ -55,6 +55,9 @@ def apple_card(debt, as_of: date) -> Decimal:
     ``past_due`` – any past due amounts
     ``financing_balance`` – balance tied to financing plans (if any)
     ``installment_due`` – installment amount(s) due for financing plans
+    
+    The resulting minimum payment is the usual payment calculation plus any
+    billed interest, installment amounts, and past due totals.
     """
 
     args = getattr(debt, "min_payment_args", {})
@@ -67,12 +70,11 @@ def apple_card(debt, as_of: date) -> Decimal:
     total_balance = debt.balance
     regular_balance = total_balance - financing_balance
 
-    base = ((regular_balance - unpaid_daily_cash) * Decimal("0.01") +
-            unpaid_daily_cash + interest_billed)
+    base = ((regular_balance - unpaid_daily_cash) * Decimal("0.01") + unpaid_daily_cash)
     base = base.quantize(Decimal("1"), rounding=ROUND_UP)
     base = max(Decimal("25"), base)
 
-    payment = base + installment_due + past_due
+    payment = base + interest_billed + installment_due + past_due
     if total_balance < payment:
         payment = total_balance
     return payment

--- a/minimum_payments.py
+++ b/minimum_payments.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Minimum payment calculation formulas for various debts.
+
+Each function here takes a ``debt`` object and an ``as_of`` date and returns
+its calculated minimum payment as a ``Decimal``.  Formulas are centralized in
+this module so they can be easily maintained or extended for additional
+cardholder agreements.
+"""
+
+from datetime import date
+from decimal import Decimal, ROUND_HALF_UP, ROUND_UP
+from calendar import monthrange
+from typing import Callable, Dict
+
+
+def _add_month(d: date) -> date:
+    """Return a date one month after ``d`` preserving month length."""
+
+    year = d.year + (d.month // 12)
+    month = d.month % 12 + 1
+    day = min(d.day, monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def credit_card(debt, as_of: date) -> Decimal:
+    """Generic credit card minimum payment.
+
+    This mirrors the previous default behaviour: 1% of the projected balance at
+    the next due date plus one month's interest.  It provides a reasonable
+    approximation for cards without a specific formula implementation.
+    """
+
+    balance = debt.balance
+    if getattr(debt, "due_date", None) and debt.apr > 0:
+        next_due = debt.due_date
+        while next_due <= as_of:
+            next_due = _add_month(next_due)
+        days = (next_due - as_of).days
+        if days > 0:
+            balance += balance * debt.apr / Decimal("36500") * days
+
+    base = balance * (debt.apr / Decimal("1200") + Decimal("0.01"))
+    return base.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def apple_card(debt, as_of: date) -> Decimal:
+    """Apple Card minimum payment calculation.
+
+    The formula is derived from the publicly documented rules.  It supports
+    optional parameters supplied via ``debt.min_payment_args``:
+
+    ``unpaid_daily_cash`` – any unpaid Daily Cash adjustments
+    ``interest_billed`` – interest billed in the current statement period
+    ``past_due`` – any past due amounts
+    ``financing_balance`` – balance tied to financing plans (if any)
+    ``installment_due`` – installment amount(s) due for financing plans
+    """
+
+    args = getattr(debt, "min_payment_args", {})
+    unpaid_daily_cash = Decimal(str(args.get("unpaid_daily_cash", 0)))
+    interest_billed = Decimal(str(args.get("interest_billed", 0)))
+    past_due = Decimal(str(args.get("past_due", 0)))
+    financing_balance = Decimal(str(args.get("financing_balance", 0)))
+    installment_due = Decimal(str(args.get("installment_due", 0)))
+
+    total_balance = debt.balance
+    regular_balance = total_balance - financing_balance
+
+    base = ((regular_balance - unpaid_daily_cash) * Decimal("0.01") +
+            unpaid_daily_cash + interest_billed)
+    base = base.quantize(Decimal("1"), rounding=ROUND_UP)
+    base = max(Decimal("25"), base)
+
+    payment = base + installment_due + past_due
+    if total_balance < payment:
+        payment = total_balance
+    return payment
+
+
+FORMULAS: Dict[str, Callable[[object, date], Decimal]] = {
+    "credit_card": credit_card,
+    "apple_card": apple_card,
+}

--- a/tests/test_apple_card_first_payment.py
+++ b/tests/test_apple_card_first_payment.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from datetime import date, timedelta
+from decimal import Decimal, ROUND_UP
+from pathlib import Path
+
+# Ensure project root on path
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+from avalanche import daily_avalanche_schedule
+
+
+def test_first_min_payment_includes_prior_interest_and_installment():
+    today = date.today()
+    due_date = today + timedelta(days=10)
+
+    debts = [
+        {
+            "name": "Apple Card",
+            "balance": 1000.0,
+            "apr": 26.24,
+            "minimum_payment": 0.0,
+            "due_date": due_date.isoformat(),
+            "min_payment_formula": "apple_card",
+            "interest_method": "apple_card",
+            "interest_billed": 90.0,
+            "installment_due": 50.0,
+            "financing_balance": 600.0,
+        }
+    ]
+
+    schedule, _, _ = daily_avalanche_schedule(0, [], [], debts, days=20, debug=True)
+
+    debt_min = next(ev for ev in schedule if ev["type"] == "debt_min")
+
+    regular_balance = Decimal("1000") - Decimal("600")
+    base = (regular_balance * Decimal("0.01")).quantize(Decimal("1"), rounding=ROUND_UP)
+    base = max(Decimal("25"), base)
+    expected = base + Decimal("90") + Decimal("50")
+
+    assert debt_min["date"] == due_date
+    assert -debt_min["amount"] == expected

--- a/tests/test_apple_card_installment.py
+++ b/tests/test_apple_card_installment.py
@@ -36,6 +36,7 @@ def test_installment_and_interest_added_and_min_payment():
             "apr": 24.0,
             "due_date": due_date.isoformat(),
             "min_payment_formula": "apple_card",
+            "interest_method": "apple_card",
             "unpaid_daily_cash": 0,
             "interest_billed": 0,
             "past_due": 0,

--- a/tests/test_apple_card_installment.py
+++ b/tests/test_apple_card_installment.py
@@ -1,0 +1,64 @@
+import os
+import sys
+from datetime import date, timedelta
+from calendar import monthrange
+from decimal import Decimal, ROUND_UP
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is in path
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+from avalanche import daily_avalanche_schedule
+
+
+def test_installment_and_interest_added_and_min_payment():
+    today = date.today()
+    end_of_month = today.replace(day=monthrange(today.year, today.month)[1])
+
+    bills = [
+        {
+            "name": "iPhone Installment",
+            "amount": 50.0,
+            "date": end_of_month.isoformat(),
+            "debt": "Apple Card",
+        }
+    ]
+
+    due_date = end_of_month + timedelta(days=10)
+
+    debts = [
+        {
+            "name": "Apple Card",
+            "balance": 1000.0,
+            "minimum_payment": 25.0,
+            "apr": 24.0,
+            "due_date": due_date.isoformat(),
+            "min_payment_formula": "apple_card",
+            "unpaid_daily_cash": 0,
+            "interest_billed": 0,
+            "past_due": 0,
+            "installment_due": 50.0,
+        }
+    ]
+
+    schedule, _, _ = daily_avalanche_schedule(0, [], bills, debts, days=40, debug=True)
+
+    # Interest added at end of month
+    interest_event = next(
+        ev for ev in schedule if ev["type"] == "debt_add" and "interest" in ev["description"].lower()
+    )
+    assert interest_event["date"] == end_of_month
+
+    rate = Decimal("24") / Decimal("36500")
+    remaining = (end_of_month - today).days + 1
+    expected_interest = rate * (Decimal("1000") * (remaining - 1) + Decimal("1050"))
+    assert float(interest_event["amount"]) == pytest.approx(float(expected_interest), rel=1e-4)
+
+    debt_min = next(ev for ev in schedule if ev["type"] == "debt_min")
+    regular_balance = Decimal("1000") + Decimal("50") + expected_interest
+    base = (regular_balance * Decimal("0.01")).quantize(Decimal("1"), rounding=ROUND_UP)
+    base = max(Decimal("25"), base)
+    expected_min = base + expected_interest + Decimal("50")
+    assert float(-debt_min["amount"]) == pytest.approx(float(expected_min), rel=1e-4)

--- a/tests/test_apple_card_interest.py
+++ b/tests/test_apple_card_interest.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from decimal import Decimal, ROUND_HALF_UP
+from datetime import date
+from pathlib import Path
+
+# Ensure project root is on path
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+import avalanche
+
+
+def test_apple_card_interest_no_compounding(monkeypatch):
+    class FixedDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2023, 1, 1)
+
+    monkeypatch.setattr(avalanche, "date", FixedDate)
+
+    debts = [
+        {
+            "name": "Apple Card",
+            "balance": 1000.0,
+            "apr": 24.0,
+            "minimum_payment": 0.0,
+            "min_payment_formula": "apple_card",
+        }
+    ]
+
+    debt_log = []
+    _, after, _ = avalanche.daily_avalanche_schedule(
+        0, [], [], debts, days=364, debug=True, debt_log=debt_log
+    )
+
+    info = after[0]
+
+    principal = Decimal("1000")
+    apr = Decimal("24")
+    current = FixedDate.today()
+    end = current.replace(year=current.year + 1)
+    expected = Decimal("0")
+    while current < end:
+        next_month = current.replace(day=1)
+        if current.month == 12:
+            next_month = next_month.replace(year=current.year + 1, month=1)
+        else:
+            next_month = next_month.replace(month=current.month + 1)
+        days = (next_month - current).days
+        month_interest = principal * apr / Decimal("36500") * days
+        expected += month_interest.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        current = next_month
+
+    assert info["interest_charges"] == expected
+    assert info["balance"] == principal + expected
+    assert debt_log[0]["interest_charges"]["Apple Card"] == Decimal("0")
+    assert debt_log[-1]["interest_charges"]["Apple Card"] == expected
+

--- a/tests/test_apple_card_interest.py
+++ b/tests/test_apple_card_interest.py
@@ -25,6 +25,7 @@ def test_apple_card_interest_no_compounding(monkeypatch):
             "apr": 24.0,
             "minimum_payment": 0.0,
             "min_payment_formula": "apple_card",
+            "interest_method": "apple_card",
         }
     ]
 

--- a/tests/test_bill_term.py
+++ b/tests/test_bill_term.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from datetime import date, timedelta
+from calendar import monthrange
+from pathlib import Path
+
+# Ensure project root on path
+sys.path.insert(0, os.path.abspath(os.path.join(Path(__file__).resolve().parent, "..")))
+
+from avalanche import daily_avalanche_schedule
+
+
+def test_bill_occurs_only_for_term_months():
+    today = date.today()
+    bills = [
+        {
+            "name": "Installment",
+            "amount": 10.0,
+            "date": today.isoformat(),
+            "debt": "Card",
+            "term_months": 2,
+        }
+    ]
+    debts = [
+        {
+            "name": "Card",
+            "balance": 0.0,
+            "apr": 0.0,
+            "minimum_payment": 0.0,
+            "due_date": (today + timedelta(days=30)).isoformat(),
+        }
+    ]
+
+    schedule, _, _ = daily_avalanche_schedule(0, [], bills, debts, days=90)
+
+    adds = [ev for ev in schedule if ev["type"] == "debt_add"]
+    assert len(adds) == 2
+    assert adds[0]["date"] == today
+
+    year = today.year + (today.month // 12)
+    month = today.month % 12 + 1
+    day = min(today.day, monthrange(year, month)[1])
+    assert adds[1]["date"] == date(year, month, day)

--- a/tests/test_debt_add_min_payment.py
+++ b/tests/test_debt_add_min_payment.py
@@ -27,6 +27,7 @@ def test_debt_add_updates_min_payment_and_reserves_cash():
             "apr": 0.0,
             "minimum_payment": 1.0,
             "due_date": (today + timedelta(days=10)).isoformat(),
+            "min_payment_formula": "credit_card",
         }
     ]
 

--- a/tests/test_interest.py
+++ b/tests/test_interest.py
@@ -17,10 +17,7 @@ def test_daily_interest_accrual():
     interest = loan_info["interest_accrued"]
 
     rate = Decimal("36.5") / Decimal("36500")
-    expected = Decimal("1000")
-    for _ in range(3):
-        expected += expected * rate
     precision = Decimal("0.000001")
-    assert loan_balance.quantize(precision) == expected.quantize(precision)
-    expected_interest = expected - Decimal("1000")
+    expected_interest = Decimal("1000") * rate * 3
+    assert loan_balance.quantize(precision) == Decimal("1000").quantize(precision)
     assert interest.quantize(precision) == expected_interest.quantize(precision)


### PR DESCRIPTION
## Summary
- Support per-debt minimum payment formulas with new `min_payment_formula` and argument storage
- Centralize payment calculations in `minimum_payments` module, including Apple Card rules
- Update sample data and tests to use named formulas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68911db34ba483288aebeefaef36cedb